### PR TITLE
Fix "search" when given no results, and when no arguments are given

### DIFF
--- a/dj.js
+++ b/dj.js
@@ -113,7 +113,12 @@ bot.on("message", function(message) {
 					console.log(err);
 				} else {
                     results.userId = message.author.id;
-					confirmResult(results);
+					if(results.items.length > 0) {
+						confirmResult(results);
+					}
+					else {
+						message.channel.sendMessage("Could not find any results :frowning:").then(sent => {sent.delete(5000);});
+					}
 				}
 			});
         }

--- a/dj.js
+++ b/dj.js
@@ -80,6 +80,11 @@ bot.on("message", function(message) {
 
         if (cmd === "search") {
             // interpretation of searchterm and amount of results
+			if(arg[0] === undefined) {
+				message.channel.sendMessage("I can't search for nothing, silly :laughing:").then(sent => {sent.delete(5000);});
+				message.delete(5000);
+				return;
+			}
             var amount = 1
 			var searchTerm = "";
 			if (isNaN(arg[0]) === false) {


### PR DESCRIPTION
When using the "search" command, every time youtube-node gives no results, the bot crashes. See Issue #3.