### PR TITLE
Fix bot playing game, and remove dj.bat

### DIFF
--- a/dj.bat
+++ b/dj.bat
@@ -1,2 +1,0 @@
-node "dj.js"
-pause

--- a/dj.js
+++ b/dj.js
@@ -25,7 +25,7 @@ ytsearch.setKey(config.youtubeDataAPIToken);
 bot.on("ready", function() {
     utils.consoleLog("system", "DJ is ready to operate!\n");
     bot.user.setUsername(config.displayName);
-    bot.user.setGame(`&help`);
+    bot.user.setGame(`${config.prefix}help`);
     if (config.avatarURL) {
         bot.user.setAvatar(config.avatarURL);
     }


### PR DESCRIPTION
I fixed the bot playing game to show the prefix specified in the `config.json`.

![Bot Playing Game](http://i.imgur.com/LUsY7aU.png)

I also removed the `dj.bat` file to make the bot "*not only Windows Based*". And because this: 

![Currently](http://i.imgur.com/6Qj0ogY.png)
vs
![My Fork](http://i.imgur.com/ziq9lPS.png).