### PR TITLE
Fix issue #5

### DIFF
--- a/dj.js
+++ b/dj.js
@@ -35,8 +35,11 @@ bot.on("ready", function() {
 			c[1].fetchMessages({limit: 100})
 			 .then(messages => {
 			 	for(let m of messages) {
-				 	if(m[1].content === "Rebooting... :arrows_counterclockwise:"
+					if(m[1].content === "Rebooting... :arrows_counterclockwise:"
 					   && m[1].author.equals(bot.user)) {
+						m[1].delete();
+					}
+					else if(m[1].content === config.prefix + "reboot") {
 						m[1].delete();
 					}
 			 	}

--- a/dj.js
+++ b/dj.js
@@ -29,6 +29,21 @@ bot.on("ready", function() {
     if (config.avatarURL) {
         bot.user.setAvatar(config.avatarURL);
     }
+	// Delete all reboot messages found in the last 100 messages of all channels
+	for (let c of bot.channels) {
+		if(c[1].type == "text") {
+			c[1].fetchMessages({limit: 100})
+			 .then(messages => {
+			 	for(let m of messages) {
+				 	if(m[1].content === "Rebooting... :arrows_counterclockwise:"
+					   && m[1].author.equals(bot.user)) {
+						m[1].delete();
+					}
+			 	}
+			 })
+			 .catch(console.error);
+		}
+	}
 });
 
 // command interpreter


### PR DESCRIPTION
This PR fixes issue #5. In the bots "ready" event, I added some code that loops through the last 100 messages of any channel the bot has access to. Any messages it finds that equal "Rebooting... :arrows_counterclockwise:" and that have the bot as author, get deleted. With a simple change in the condition that checks the found messages, all the messages the bot sent, that for some reason didn't get deleted, could also be deleted. The change could be implemented as follows: 

`if(m[1].author.equals(bot.user))`

vs 

`if(m[1].content === "Rebooting... :arrows_counterclockwise:" && m[1].author.equals(bot.user))`.

I tested it thoroughly and did not encounter any issues.